### PR TITLE
fix mutation of passed in json to loadJSON

### DIFF
--- a/spec/Graph.coffee
+++ b/spec/Graph.coffee
@@ -233,12 +233,41 @@ describe 'FBP Graph', ->
     """
     json = JSON.parse(jsonString)
     g = null
-    it 'should produce a Graph', (done) ->
+
+    it 'should produce a Graph when input is string', (done) ->
+      lib.graph.loadJSON jsonString, (err, instance) ->
+        return done err if err
+        g = instance
+        chai.expect(g).to.be.an 'object'
+        done()
+
+    it 'should produce a Graph when input is json', (done) ->
       lib.graph.loadJSON json, (err, instance) ->
         return done err if err
         g = instance
         chai.expect(g).to.be.an 'object'
         done()
+        
+    it 'should not mutate the inputted json object', (done) ->
+      chai.expect(Object.keys(json.processes).length).to.equal(4)
+      lib.graph.loadJSON json, (err, instance) ->
+        return done err if err
+        instance.addNode 'Split1', 'Split'
+        instance.addNode 'Split1', 'Split'
+        instance.addNode 'Split1', 'Split'
+        instance.addNode 'Split1', 'Split'
+        instance.addNode 'Split1', 'Split'
+        instance.addNode 'Split1', 'Split'
+        instance.addNode 'Split1', 'Split'
+        instance.addNode 'Split1', 'Split'
+        instance.addNode 'Split1', 'Split'
+        instance.addNode 'Split1', 'Split'
+        instance.addNode 'Split1', 'Split'
+
+        chai.expect(Object.keys(json.processes).length).to.equal(4)
+        console.log(json)
+        done()
+
     it 'should have a name', ->
       chai.expect(g.name).to.equal 'Example'
     it 'should have graph metadata intact', ->

--- a/src/Graph.coffee
+++ b/src/Graph.coffee
@@ -748,8 +748,12 @@ exports.Graph = Graph
 exports.createGraph = (name, options) ->
   new Graph name, options
 
-exports.loadJSON = (definition, callback, metadata = {}) ->
-  definition = JSON.parse definition if typeof definition is 'string'
+exports.loadJSON = (passedDefinition, callback, metadata = {}) ->
+  if typeof passedDefinition is 'string'
+    definition = JSON.parse passedDefinition
+  else
+    definition = JSON.parse JSON.stringify passedDefinition
+
   definition.properties = {} unless definition.properties
   definition.processes = {} unless definition.processes
   definition.connections = [] unless definition.connections


### PR DESCRIPTION
Previously, whatever JSON object you passed into loadJSON would be mutated (it's properties modified) outside of the function. This was due to using the same var name in the function definition as in the function. 

I wrote a new test to cover this scenario, as well as an explicit test for loading via a string, or via an object.